### PR TITLE
fix:  images  list and languages details

### DIFF
--- a/src/components/LanguageInformation/index.jsx
+++ b/src/components/LanguageInformation/index.jsx
@@ -1,17 +1,45 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { DialetoService } from '../../services';
 import styles from './styles';
 
 export function LanguageInfo({ language, style }) {
+  const [dialeto, setDialeto] = useState([]);
+
+  useEffect(() => {
+    async function getDialetos() {
+      const response = await DialetoService.getAllDialetos({
+        idLingua: language.id_lingua,
+      });
+      setDialeto(response);
+    }
+    getDialetos();
+  }, []);
+
+  const list = () =>
+    dialeto.map((etnia) => (
+      <View key={etnia.etnia.id_etnia} style={styles.scrollView}>
+        <Text style={styles.thirdtext}>Etnias Falantes: </Text>
+
+        <View style={styles.textlist}>
+          <View>
+            <Text style={styles.text}>
+              <Ionicons name="ios-people" size={20} color="gray" />
+              {'  '}
+              {etnia.etnia.nome}
+            </Text>
+          </View>
+        </View>
+      </View>
+    ));
+  console.log(language);
   return (
     <View style={[styles.textcontainer, style]}>
       <Text style={styles.firsttext}>
         Família Linguística: {language?.tronco?.nome ?? 'Isolada'}
       </Text>
-      <Text style={styles.thirdtext}>20% de falantes</Text>
-      <View style={styles.greypercentage}>
-        <View style={styles.yellowpercentage} />
-      </View>
+      <View style={{ top: '2%' }}>{list()}</View>
     </View>
   );
 }

--- a/src/components/LanguageInformation/styles.js
+++ b/src/components/LanguageInformation/styles.js
@@ -14,11 +14,18 @@ const styles = StyleSheet.create({
     color: GRAY,
     paddingTop: '2%',
   },
-  sectext: {
+  textlist: {
+    fontSize: 20,
+    fontFamily: MONTSERRAT_SEMIBOLD,
+    color: GRAY,
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  text: {
+    marginLeft: 5,
     fontFamily: MONTSERRAT_SEMIBOLD,
     fontSize: 16,
     color: GRAY,
-    paddingTop: '2%',
   },
   thirdtext: {
     fontFamily: MONTSERRAT_SEMIBOLD,

--- a/src/screens/ImageWordScreen/index.jsx
+++ b/src/screens/ImageWordScreen/index.jsx
@@ -44,10 +44,12 @@ export function ImageWordScreen() {
                 : styles.containerImage
             }
           >
-            <ImageContainer
-              palavra={currentWord.nome}
-              image={currentWord.url}
-            />
+            {currentWord.url === undefined ? null : (
+              <ImageContainer
+                palavra={currentWord.nome}
+                image={currentWord.url}
+              />
+            )}
           </View>
         ))
       : null;


### PR DESCRIPTION
## Description

Ajustes nas páginas de Lista de Imagens e Detalhes de Língua

## Solve (Issue)
Resolve #170
https://github.com/fga-eps-mds/2021.1-Multilind-Docs/issues/170

## Tasks
- [x] Não mostrar palavras que não tem imagem (Lista de imagem)
- [x] Detalhes da Lingua: colocar as etnias falantes em cima e retirar botao mais informações

## Assets
![image](https://user-images.githubusercontent.com/69825746/139343827-aa822f5f-36e7-4c1d-b70c-8c374855eaf5.png)

